### PR TITLE
Implementation of a rockcraft-built nginx rock

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
+        with:
+          channel: 5.10/stable
+
+      - name: Install rockcraft
+        run: |
+          sudo snap install --classic --channel edge rockcraft
+      - name: Build ROCK
+        run: rockcraft pack --verbose
+
+      - name: Upload locally built ROCK artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: nginx-rock
+          path: "nginx_*.rock"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,5 +41,5 @@ jobs:
             --insecure-policy \
             copy \
             oci-archive:"${{ env.IMAGE_NAME }}_${version}_amd64.rock" \
-            docker-daemon:"${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}"
+            docker://${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}
           docker push ${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,4 +41,5 @@ jobs:
             --insecure-policy \
             copy \
             oci-archive:"${{ env.IMAGE_NAME }}_${version}_amd64.rock" \
-            docker://${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}
+            docker-daemon:"${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}"
+          docker push ${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,4 +42,3 @@ jobs:
             copy \
             oci-archive:"${{ env.IMAGE_NAME }}_${version}_amd64.rock" \
             docker://${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}
-          docker push ${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,12 +22,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
       - name: Install skopeo
         run: |
           sudo snap install --devmode --channel edge skopeo

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,51 @@
+name: Publish
+
+on:
+  workflow_call:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nginx
+
+jobs:
+
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Install skopeo
+        run: |
+          sudo snap install --devmode --channel edge skopeo
+
+      - name: Install yq
+        run: |
+          sudo snap install yq
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: nginx-rock
+
+      - name: Import and push to github package
+        run: |
+          version="$(cat rockcraft.yaml | yq e '.version')"
+          sudo skopeo \
+            --insecure-policy \
+            copy \
+            oci-archive:"${{ env.IMAGE_NAME }}_${version}_amd64.rock" \
+            docker-daemon:"${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}"
+          docker push ${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}

--- a/.github/workflows/push_any.yaml
+++ b/.github/workflows/push_any.yaml
@@ -15,4 +15,4 @@ jobs:
 
   test:
     needs: build
-    users: ./.github/workflows/test.yaml
+    uses: ./.github/workflows/test.yaml

--- a/.github/workflows/push_any.yaml
+++ b/.github/workflows/push_any.yaml
@@ -12,3 +12,7 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
+
+  test:
+    needs: build
+    users: ./.github/workflows/test.yaml

--- a/.github/workflows/push_any.yaml
+++ b/.github/workflows/push_any.yaml
@@ -1,0 +1,14 @@
+name: Push (any)
+
+on:
+  push:
+    branches-ignore:
+      - "main"
+    paths:
+      - "rockcraft.yaml"
+      - "files/**"
+      - ".github/workflows/**.yaml"
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml

--- a/.github/workflows/push_main.yaml
+++ b/.github/workflows/push_main.yaml
@@ -2,8 +2,8 @@ name: Push (main)
 
 on:
   push:
-#    branches:
-#      - main
+    branches:
+      - main
     paths:
       - "rockcraft.yaml"
       - ".github/workflows/**.yaml"

--- a/.github/workflows/push_main.yaml
+++ b/.github/workflows/push_main.yaml
@@ -1,0 +1,17 @@
+name: Push (main)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "rockcraft.yaml"
+      - ".github/workflows/**.yaml"
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml
+
+  publish:
+    needs: build
+    uses: ./.github/workflows/publish.yaml

--- a/.github/workflows/push_main.yaml
+++ b/.github/workflows/push_main.yaml
@@ -2,8 +2,8 @@ name: Push (main)
 
 on:
   push:
-    branches:
-      - main
+#    branches:
+#      - main
     paths:
       - "rockcraft.yaml"
       - ".github/workflows/**.yaml"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: Tests
 
 on:
   workflow_call:
@@ -9,7 +9,7 @@ env:
 
 jobs:
 
-  test:
+  tests:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -42,7 +42,7 @@ jobs:
             oci-archive:"${{ env.IMAGE_NAME }}_${version}_amd64.rock" \
             docker-daemon:"${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}"
 
-      - name: Test
+      - name: Tests
         run: |
           docker run --name nginx -p 8080:80 -d ${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}
           cd tests && tox -e integration

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,48 @@
+name: Publish
+
+on:
+  workflow_call:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nginx
+
+jobs:
+
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Install skopeo
+        run: |
+          sudo snap install --devmode --channel edge skopeo
+
+      - name: Install yq
+        run: |
+          sudo snap install yq
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: nginx-rock
+
+      - name: Import
+        run: |
+          version="$(cat rockcraft.yaml | yq e '.version')"
+          sudo skopeo \
+            --insecure-policy \
+            copy \
+            oci-archive:"${{ env.IMAGE_NAME }}_${version}_amd64.rock" \
+            docker-daemon:"${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}"
+
+      - name: Test
+        run: |
+          docker run --name nginx -p 8080:80 -d ${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}
+          cd tests && tox -e integration

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,12 +15,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
       - name: Install skopeo
         run: |
           sudo snap install --devmode --channel edge skopeo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,10 @@ jobs:
             oci-archive:"${{ env.IMAGE_NAME }}_${version}_amd64.rock" \
             docker-daemon:"${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}"
 
+      - name: Install tox
+        run: |
+          pip install tox
+
       - name: Tests
         run: |
           version="$(cat rockcraft.yaml | yq e '.version')"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,5 +44,6 @@ jobs:
 
       - name: Tests
         run: |
-          docker run --name nginx -p 8080:80 -d ${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}
+          version="$(cat rockcraft.yaml | yq e '.version')"
+          docker run -d -p 8080:80 ${{ env.REGISTRY }}/canonical/${{ env.IMAGE_NAME }}:${version}
           cd tests && tox -e integration

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Publish
+name: Test
 
 on:
   workflow_call:
@@ -9,7 +9,7 @@ env:
 
 jobs:
 
-  publish:
+  test:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+## Build and deploy
+
+```bash
+rockcraft pack -v
+sudo skopeo --insecure-policy copy oci-archive:nginx_1.23.3_amd64.rock docker-daemon:nginx:1.23.3
+docker run nginx:1.23.3
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Canonical Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# nginx-rock
+# nginx Rock
+
+OCI image for [nginx](https://www.nginx.com/) based on Ubuntu 22.04 built using [rockcraft](https://github.com/canonical/rockcraft). 
+
+## Usage
+
+```bash
+docker pull ghcr.io/canonical/nginx:1.23.3
+docker run -it ghcr.io/canonical/nginx:1.23.3
+```

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -8,10 +8,9 @@ license: Apache-2.0
 platforms:
   amd64:
 
-cmd: ["nginx", "-g", "daemon off;"]
+cmd: ["nginx"]
 
 parts:
-
   nginx:
     plugin: autotools
     source: https://nginx.org/download/nginx-1.23.3.tar.gz

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 platforms:
   amd64:
 
-cmd: ["nginx"]
+cmd: ["nginx", "-g", "daemon off;"]
 
 parts:
   nginx:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -20,7 +20,7 @@ parts:
       - libssl-dev
       - zlib1g-dev
     stage-packages:
-      - ca-certificates
+      - ca-certificates_data
     autotools-configure-parameters:
       - --prefix=/var/www/html
       - --sbin-path=/usr/sbin/nginx

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -20,8 +20,6 @@ parts:
       - libssl-dev
       - zlib1g-dev
     stage-packages:
-      - libpcre3-dev
-      - libssl-dev
       - ca-certificates
     autotools-configure-parameters:
       - --prefix=/var/www/html

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,0 +1,42 @@
+name: nginx
+version: "1.23.3"
+build-base: ubuntu:22.04
+base: ubuntu:22.04
+summary: nginx web server
+description: nginx [engine x] is an HTTP and reverse proxy server, a mail proxy server, and a generic TCP/UDP proxy server.
+license: Apache-2.0
+platforms:
+  amd64:
+
+cmd: ["nginx", "-g", "daemon off;"]
+
+parts:
+
+  nginx:
+    plugin: autotools
+    source: https://nginx.org/download/nginx-1.23.3.tar.gz
+    build-packages:
+      - libgd-dev
+      - libpcre3-dev
+      - libssl-dev
+      - zlib1g-dev
+    stage-packages:
+      - libpcre3-dev
+      - libssl-dev
+      - ca-certificates
+    autotools-configure-parameters:
+      - --prefix=/var/www/html
+      - --sbin-path=/usr/sbin/nginx
+      - --conf-path=/etc/nginx/nginx.conf
+      - --http-log-path=/var/log/nginx/access.log
+      - --error-log-path=/var/log/nginx/error.log
+      - --with-pcre
+      - --lock-path=/var/lock/nginx.lock
+      - --pid-path=/var/run/nginx.pid
+      - --with-http_ssl_module
+      - --with-http_image_filter_module=dynamic
+      - --modules-path=/etc/nginx/modules
+      - --with-http_v2_module
+      - --with-stream=dynamic
+      - --with-http_addition_module
+      - --with-http_mp4_module

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests for the nginx rock.
+
+These tests assume that the nginx container is running and available at the url:port defined below.
+"""
+
+import requests  # type: ignore[import]
+
+import unittest
+
+NGINX_DOCKER_URL = 'http://localhost'
+NGINX_DOCKER_PORT = 8080
+
+
+class TestNginxRock(unittest.TestCase):
+    """Integration tests for the nginx rock."""
+
+    def test_given_nginx_container_is_running_when_http_get_then_nginx_welcome_message_is_returned(
+        self
+    ):
+        response = requests.get(f"{NGINX_DOCKER_URL}:{NGINX_DOCKER_PORT}")
+
+        assert response.status_code == 200
+        assert "Welcome to nginx!" in response.text

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -1,0 +1,52 @@
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.black]
+line-length = 99
+target-version = ["py38"]
+
+[tool.isort]
+profile = "black"
+
+[tool.flake8]
+max-line-length = 99
+max-doc-length = 99
+max-complexity = 10
+exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
+select = ["E", "W", "F", "C", "N", "R", "D", "H"]
+per-file-ignores = ["tests/*:D100,D101,D102,D103,D107"]
+docstring-convention = "google"
+copyright-check = "True"
+copyright-author = "Canonical Ltd."
+copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+
+[tool.mypy]
+pretty = true
+python_version = 3.8
+mypy_path = "$MYPY_CONFIG_FILE_DIR/src:$MYPY_CONFIG_FILE_DIR/lib:$MYPY_CONFIG_FILE_DIR/tests/unit"
+follow_imports = "normal"
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unused_configs = true
+show_traceback = true
+show_error_codes = true
+namespace_packages = true
+explicit_package_bases = true
+check_untyped_defs = true
+allow_redefinition = true
+
+# Ignore libraries that do not have type hint nor stubs
+[[tool.mypy.overrides]]
+module = ["ops.*", "kubernetes.*", "flatten_json.*", "git.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["charms.*"]
+follow_imports = "silent"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+log_cli_level = "INFO"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -1,0 +1,75 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+[tox]
+skipsdist=True
+skip_missing_interpreters = True
+envlist = integration
+
+[vars]
+integration_test_path = {toxinidir}/integration/
+
+[testenv]
+deps =
+    pytest
+    pytest-operator
+setenv =
+    PYTHONPATH = {toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
+    PYTHONPATH
+    HOME
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
+
+[testenv:fmt]
+description = Apply coding style standards to code
+deps =
+    black
+    isort
+commands =
+    isort {[vars]integration_test_path}
+    black {[vars]integration_test_path}
+
+[testenv:lint]
+description = Check code against coding style standards
+deps =
+    black
+    flake8 == 4.0.1
+    flake8-docstrings
+    flake8-copyright
+    flake8-builtins
+    pyproject-flake8
+    pep8-naming
+    isort
+commands =
+    pflake8 {[vars]integration_test_path}
+    isort --check-only --diff {[vars]integration_test_path}
+    black --check --diff {[vars]integration_test_path}
+
+[testenv:static]
+description = Run static analysis checks
+deps =
+    -r{toxinidir}/requirements.txt
+    mypy
+    types-PyYAML
+    pytest
+    pytest-operator
+    juju
+    types-setuptools
+    types-toml
+commands =
+    mypy {[vars]integration_test_path} {posargs}
+setenv =
+    PYTHONPATH = ""
+
+[testenv:integration]
+description = Run integration tests
+deps =
+    pytest
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]integration_test_path}


### PR DESCRIPTION
# OVERVIEW

This PR implements a rockcraft-built rock for nginx based on Ubuntu 22.04. It also takes care of publishing it to github's package registry after each PR is merged.

## Image size

Currently, the resulting nginx image is 91.3MB and the upstream version is 142MB (35% reduction). In the future we could decrease it even more by using a bare base instead of Ubuntu 22.04.