### PR TITLE
Uses pebble service definition

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -8,7 +8,11 @@ license: Apache-2.0
 platforms:
   amd64:
 
-cmd: ["nginx", "-g", "daemon off;"]
+services:
+  nginx:
+    override: replace
+    command: nginx -g 'daemon off;'
+    startup: enabled
 
 parts:
 


### PR DESCRIPTION
### Overview

[Pebble is the new official entrypoint in rocks](https://discourse.canonical.com/t/the-rocks-gazette-2023-7/1762) and this PR introduces its use in the nginx rock.
