### PR TITLE
chore: move ownership to observability team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability


### PR DESCRIPTION
# Description

Move ownership to observability team. I also added the observability team as admins on this repo.

This was discussed as part of #23 