### PR TITLE
chore: bump build-base to ubuntu@26.04

### DIFF
--- a/1.28/rockcraft.yaml
+++ b/1.28/rockcraft.yaml
@@ -12,8 +12,7 @@ environment:
   PEBBLE_PERSIST: never # Allow running in read-only mode
 
 base: bare
-# TODO change to 26.04 once 26.04 is officially released
-build-base: devel
+build-base: ubuntu@26.04
 
 platforms:
   amd64:

--- a/1.28/spread/general/test_custom_config/task.yaml
+++ b/1.28/spread/general/test_custom_config/task.yaml
@@ -9,7 +9,7 @@ execute: |
   docker run -d --rm --name nginx-rock -p 48080:80 \
     -v $(pwd)/html:/srv/www/html:ro \
     -v $(pwd)/nginx_simple.conf:/etc/nginx/nginx.conf:ro \
-    nginx:1.28-26.04
+    rockcraft-test:latest
 
   # Wait for Nginx to be ready (timeout after 30 seconds)
   timeout 30 bash -c 'until curl -sSf http://127.0.0.1:48080 >/dev/null; do sleep 1; done'

--- a/1.28/spread/general/test_default_config/task.yaml
+++ b/1.28/spread/general/test_default_config/task.yaml
@@ -6,7 +6,7 @@ execute: |
   trap "docker stop nginx-rock >/dev/null 2>&1 || true" EXIT
 
   # Run the Nginx container
-  docker run -d --rm --name nginx-rock -p 48080:80 nginx:1.28-26.04
+  docker run -d --rm --name nginx-rock -p 48080:80 rockcraft-test:latest
 
   # Wait for Nginx to be ready (timeout after 30 seconds)
   timeout 30 bash -c 'until curl -sSf http://127.0.0.1:48080 >/dev/null; do sleep 1; done'

--- a/1.28/spread/general/test_default_config_ipv6/task.yaml
+++ b/1.28/spread/general/test_default_config_ipv6/task.yaml
@@ -6,7 +6,7 @@ execute: |
   trap "docker stop nginx-rock >/dev/null 2>&1 || true" EXIT
 
   # Run the Nginx container
-  docker run -d --rm --name nginx-rock -p 48080:80 nginx:1.28-26.04
+  docker run -d --rm --name nginx-rock -p 48080:80 rockcraft-test:latest
 
   # Wait for Nginx to be ready (timeout after 30 seconds)
   timeout 30 bash -c 'until curl -sSf http://127.0.0.1:48080 >/dev/null; do sleep 1; done'

--- a/1.28/spread/general/test_reverse_proxy/task.yaml
+++ b/1.28/spread/general/test_reverse_proxy/task.yaml
@@ -11,7 +11,7 @@ execute: |
   docker run -d --rm --name nginx-backend-rock -p 48080:80 \
     -v $(pwd)/html:/var/www/html:ro \
     --network test-network \
-    nginx:1.28-26.04
+    rockcraft-test:latest
 
   # Wait for Nginx to be ready (timeout after 30 seconds)
   timeout 30 bash -c 'until curl -sSf http://127.0.0.1:48080 >/dev/null; do sleep 1; done'
@@ -32,7 +32,7 @@ execute: |
   docker run -d --rm --name nginx-proxy-rock -p 48070:48070 \
     -v $(pwd)/nginx_reverse_proxy.conf:/etc/nginx/nginx.conf:ro \
     --network test-network \
-    nginx:1.28-26.04
+    rockcraft-test:latest
 
   # Wait for Nginx to be ready (timeout after 30 seconds)
   timeout 30 bash -c 'until curl -sSf http://127.0.0.1:48070 >/dev/null; do sleep 1; done'

--- a/1.28/spread/general/test_static_content/task.yaml
+++ b/1.28/spread/general/test_static_content/task.yaml
@@ -6,7 +6,7 @@ execute: |
   trap "docker stop nginx-rock >/dev/null 2>&1 || true" EXIT
 
   # Run the Nginx container
-  docker run -d --rm --name nginx-rock -p 48080:80 -v $(pwd)/static:/var/www/html:ro nginx:1.28-26.04
+  docker run -d --rm --name nginx-rock -p 48080:80 -v $(pwd)/static:/var/www/html:ro rockcraft-test:latest
 
   # Wait for Nginx to be ready (timeout after 30 seconds)
   timeout 30 bash -c 'until curl -sSf http://127.0.0.1:48080/test.txt >/dev/null; do sleep 1; done'

--- a/1.28/spread/general/test_static_content_ro/task.yaml
+++ b/1.28/spread/general/test_static_content_ro/task.yaml
@@ -13,6 +13,7 @@ execute: |
     -v $nginx_scratch:/var/lib/nginx \
     -v "$nginx_scratch:/var/log/nginx" \
     -v "$nginx_scratch:/var/run" \
+    -v "$nginx_scratch:/tmp" \
     -v $(pwd)/static:/var/www/html:ro \
     rockcraft-test:latest
 

--- a/1.28/spread/general/test_static_content_ro/task.yaml
+++ b/1.28/spread/general/test_static_content_ro/task.yaml
@@ -14,7 +14,7 @@ execute: |
     -v "$nginx_scratch:/var/log/nginx" \
     -v "$nginx_scratch:/var/run" \
     -v $(pwd)/static:/var/www/html:ro \
-    nginx:1.28-26.04
+    rockcraft-test:latest
 
   # Wait for Nginx to be ready (timeout after 30 seconds)
   timeout 30 bash -c 'until curl -sSf http://127.0.0.1:48080/test.txt >/dev/null; do sleep 1; done'

--- a/1.28/spread/general/test_static_content_ro/task.yaml
+++ b/1.28/spread/general/test_static_content_ro/task.yaml
@@ -2,31 +2,24 @@ summary: Create an nginx container serving static content read-only
 
 execute: |
 
-  # Clean up on exit
-  trap "docker stop nginx-rock >/dev/null 2>&1 || true" EXIT
+  # Clean up on exit (no --rm so we can capture logs on failure)
+  trap "docker logs nginx-rock 2>/dev/null; docker rm -f nginx-rock >/dev/null 2>&1 || true" EXIT
 
   # Create tmp cache dir
-  nginx_scratch=$(mktemp -d  /tmp/nginx-cache-XXXXXXX)
+  nginx_scratch=$(mktemp -d /tmp/nginx-cache-XXXXXXX)
 
   # Run the Nginx container
   # --read-only makes the rootfs read-only; writable paths must be mounted.
   # Pebble (entrypoint) needs /var/lib/pebble writable for runtime state.
   # Nginx needs /var/lib/nginx, /var/log/nginx, /var/run, and /tmp.
-  docker run -d --rm --name nginx-rock -p 48080:80 --read-only \
+  docker run -d --name nginx-rock -p 48080:80 --read-only \
     --tmpfs /var/lib/pebble \
-    -v $nginx_scratch:/var/lib/nginx \
+    --tmpfs /tmp \
+    --tmpfs /run \
+    -v "$nginx_scratch:/var/lib/nginx" \
     -v "$nginx_scratch:/var/log/nginx" \
-    -v "$nginx_scratch:/var/run" \
-    -v "$nginx_scratch:/tmp" \
-    -v $(pwd)/static:/var/www/html:ro \
+    -v "$(pwd)/static:/var/www/html:ro" \
     rockcraft-test:latest
-
-  # Show container logs if nginx fails to start
-  sleep 2
-  if ! docker inspect --format='{{.State.Running}}' nginx-rock 2>/dev/null | grep -q true; then
-    echo "Container failed to start, logs:"
-    docker logs nginx-rock 2>&1 || true
-  fi
 
   # Wait for Nginx to be ready (timeout after 30 seconds)
   timeout 30 bash -c 'until curl -sSf http://127.0.0.1:48080/test.txt >/dev/null; do sleep 1; done'

--- a/1.28/spread/general/test_static_content_ro/task.yaml
+++ b/1.28/spread/general/test_static_content_ro/task.yaml
@@ -9,13 +9,24 @@ execute: |
   nginx_scratch=$(mktemp -d  /tmp/nginx-cache-XXXXXXX)
 
   # Run the Nginx container
+  # --read-only makes the rootfs read-only; writable paths must be mounted.
+  # Pebble (entrypoint) needs /var/lib/pebble writable for runtime state.
+  # Nginx needs /var/lib/nginx, /var/log/nginx, /var/run, and /tmp.
   docker run -d --rm --name nginx-rock -p 48080:80 --read-only \
+    --tmpfs /var/lib/pebble \
     -v $nginx_scratch:/var/lib/nginx \
     -v "$nginx_scratch:/var/log/nginx" \
     -v "$nginx_scratch:/var/run" \
     -v "$nginx_scratch:/tmp" \
     -v $(pwd)/static:/var/www/html:ro \
     rockcraft-test:latest
+
+  # Show container logs if nginx fails to start
+  sleep 2
+  if ! docker inspect --format='{{.State.Running}}' nginx-rock 2>/dev/null | grep -q true; then
+    echo "Container failed to start, logs:"
+    docker logs nginx-rock 2>&1 || true
+  fi
 
   # Wait for Nginx to be ready (timeout after 30 seconds)
   timeout 30 bash -c 'until curl -sSf http://127.0.0.1:48080/test.txt >/dev/null; do sleep 1; done'

--- a/1.28/spread/general/test_static_content_ro/task.yaml
+++ b/1.28/spread/general/test_static_content_ro/task.yaml
@@ -8,12 +8,11 @@ execute: |
   # Create tmp cache dir
   nginx_scratch=$(mktemp -d /tmp/nginx-cache-XXXXXXX)
 
-  # Run the Nginx container
-  # --read-only makes the rootfs read-only; writable paths must be mounted.
-  # Pebble (entrypoint) needs /var/lib/pebble writable for runtime state.
-  # Nginx needs /var/lib/nginx, /var/log/nginx, /var/run, and /tmp.
+  # Run the Nginx container in read-only mode.
+  # Use an anonymous volume for pebble state so layer files from the image
+  # are preserved (tmpfs would clobber /var/lib/pebble/default/layers/).
   docker run -d --name nginx-rock -p 48080:80 --read-only \
-    --tmpfs /var/lib/pebble \
+    -v /var/lib/pebble/default \
     --tmpfs /tmp \
     --tmpfs /run \
     -v "$nginx_scratch:/var/lib/nginx" \

--- a/1.28/spread/general/test_stub_status_config/task.yaml
+++ b/1.28/spread/general/test_stub_status_config/task.yaml
@@ -7,7 +7,7 @@ execute: |
 
   docker run -d --rm --name nginx-rock -p 48080:80 \
     -v $(pwd)/nginx_stub_status.conf:/etc/nginx/nginx.conf:ro \
-    nginx:1.28-26.04
+    rockcraft-test:latest
 
   # Wait for Nginx to be ready (timeout after 30 seconds)
   timeout 30 bash -c 'until curl -sSf http://127.0.0.1:48080 >/dev/null; do sleep 1; done'

--- a/rocks.just
+++ b/rocks.just
@@ -4,6 +4,11 @@ set shell := ["bash", "-uc"]
 rock_name := `echo ${PWD##*/} | sed 's/-rock$//'`  # Get the rock name from the folder name
 latest_version := `find . -name rockcraft.yaml -printf '%h\n' | sort -V | tail -n1 | sed 's@./@@'`
 
+# LTS end-of-life overrides. Override this variable in the local 'justfile'.
+# Define mappings from LTS minor versions to their EOL date in YYYY-MM-DD format.
+# Example: lts_releases := '{"2.14": "2026-12-31", "2.12": "2025-06-30"}'
+lts_releases := '{}'
+
 [private]
 @default:
   just --list
@@ -61,15 +66,47 @@ test version=latest_version:
 [group("security")]
 sbom version=latest_version:
   syft {{version}}/*.rock -o "spdx-json={{version}}/rock.sbom.json"
+  @echo "✓ SBOM saved to {{version}}/rock.sbom.json"
+
+# Perform a securiy scan
+[group("security")]
+scan version=latest_version: (sbom version)
+  uvx --from=trivy-py trivy sbom "{{version}}/rock.sbom.json"
+  @echo "✓ Vulnerability scan done"
+
+# Check whether CVEs affect the upstream project
+[group("security")]
+govulncheck source_repo version=latest_version:
+  #!/usr/bin/env bash
+  set -e
+  echo "Cloning {{source_repo}}"
+  which -s govulncheck || { echo "govulncheck not found; install it with:  go install golang.org/x/vuln/cmd/govulncheck@latest"; exit 1; }
+  TMP_DIR="$(mktemp -d)"
+  gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "{{version}}" --depth 1 2>/dev/null \
+    || gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "v{{version}}" --depth 1
+  if [[ ! -f "$TMP_DIR/{{source_repo}}/go.mod" ]]; then
+    echo "⨯ {{source_repo}} is not a Go project (go.mod is missing)"
+    exit 2
+  fi
+  echo "Running 'govulncheck' (this may take a while)"
+  vuln_exit=0; (cd "$TMP_DIR/{{source_repo}}" && govulncheck ./...) || vuln_exit=$?
+  rm -rf "$TMP_DIR"
+  if [ "$vuln_exit" -ne 0 ]; then echo "⨯ 'govulncheck' failed"; exit "$vuln_exit"; fi
+  echo "✓ 'govulncheck' passed."
 
 # Generate a rock for the latest version of the upstream project
 [arg("source_repo", help="Repository of the upstream project in 'org/repo' form")]
 [group("maintenance")]
-update source_repo:
+update source_repo release_tag="":
   #!/usr/bin/env bash
   set -e
-  latest_release="$(gh release list --repo {{source_repo}} --exclude-pre-releases --limit=1 --json tagName --jq '.[0].tagName')"
-  echo "Latest release for {{source_repo}} is $latest_release"
+  if [[ -z "{{release_tag}}" ]]; then
+    latest_release="$(gh release list --repo {{source_repo}} --exclude-pre-releases --limit=1 --json tagName --jq '.[0].tagName')"
+    echo "Latest release for {{source_repo}} is $latest_release"
+  else
+    latest_release="{{release_tag}}"
+    echo "Release version manually set to $latest_release"
+  fi
   # Explicitly filter out prefixes for known rocks, so we can notice if a new rock has a different schema
   version="${latest_release}"
   version="${version#mimir-}"  # mimir
@@ -99,6 +136,7 @@ update source_repo:
 [group("maintenance")]
 refresh:
   #!/usr/bin/env bash
+  which -s gh || { echo "gh not found"; exit 1; }
   refresh_folder="blueprints/rocks"
   api_path="repos/canonical/observability/contents/$refresh_folder"
   for file in rocks.just spread.yaml; do
@@ -130,22 +168,46 @@ release-oci-factory version=latest_version support="minor" risk="stable":
   if [[ -z "$GITHUB_TOKEN" ]]; then echo "× Please export GITHUB_TOKEN for the user observability-noctua-bot"; exit 1; fi
   if [ ! -e {{version}}/*.rock ]; then echo "× Error: rock not found. Please run 'just pack {{version}}' first."; exit 2; fi
   repository="$(git remote get-url origin | sed -E 's#(git@[^:]+:|https?://[^/]+/)##; s/\.git$//')"
+  # Extract the base from the rockcraft.yaml (e.g. "ubuntu@24.04" -> "24.04")
+  # For bare-based rocks, fall back to build-base (e.g. "ubuntu@26.04" -> "26.04")
+  rock_base="$(yq -r '.base' "{{version}}/rockcraft.yaml" | sed 's/.*@//')"
+  if [[ "$rock_base" == "bare" ]]; then
+    rock_base="$(yq -r '.["build-base"]' "{{version}}/rockcraft.yaml" | sed 's/.*@//')"
+  fi
+  echo "Detected base: $rock_base"
   # Clone the oci-factory and push data to it
   gh repo sync --force observability-noctua-bot/oci-factory
   TMP_DIR="$(mktemp -d)"
   git clone https://github.com/observability-noctua-bot/oci-factory "$TMP_DIR/oci-factory"
   echo "✓ Cloned observability-noctua-bot/oci-factory"
   # Build the OCI Factory manifest
+  # Check if this version has a custom EOL in lts_releases
+  minor_version="$(echo "{{version}}" | grep -oP '^\d+\.\d+')"
+  eol_date="$(echo '{{lts_releases}}' | jq -r --arg v "$minor_version" '.[$v] // empty')"
+  eol_flag=""
+  if [[ -n "$eol_date" ]]; then
+    eol_flag="--eol=$eol_date"
+    echo "LTS release detected: EOL set to $eol_date"
+  fi
   echo "Building the OCI Factory manifest..."; echo
+  manifest_file="$TMP_DIR/oci-factory/oci/{{rock_name}}/image.yaml"
   uvx --from=git+https://github.com/lucabello/noctua noctua rock manifest \
     "$repository" \
     --commit="$(git rev-parse HEAD)" \
-    --base=24.04 \
+    --base="$rock_base" \
     --support="{{support}}" \
     --risk="{{risk}}" \
     --version="{{version}}" \
-    | tee "$TMP_DIR/oci-factory/oci/{{rock_name}}/image.yaml"
+    $eol_flag \
+    | tee "$manifest_file"
   echo; echo "✓ OCI Factory manifest generated"
+  # If there's nothing to upload, exit early
+  upload_count="$(cat "$manifest_file" | yq '.upload | length')"
+  if [[ "$upload_count" -eq 0 ]]; then
+    echo "✓ Nothing to update in OCI Factory"
+    rm -rf "$TMP_DIR"
+    exit 0
+  fi
   # Commit the changes and create a PR
   pushd "$TMP_DIR/oci-factory" >/dev/null
   git config user.name observability-noctua-bot

--- a/spread.yaml
+++ b/spread.yaml
@@ -25,9 +25,7 @@ suites:
       sudo snap install --classic rockcraft
 
       # Wait for docker daemon to come online
-      sudo apt install --yes retry
-      retry --times=10 --delay 2 -- docker run hello-world
-      sudo apt remove --yes retry
+      for i in $(seq 1 10); do docker info >/dev/null 2>&1 && break || sleep 2; done
 
       # Load the rock into docker
       sudo rockcraft.skopeo --insecure-policy copy "oci-archive:$CRAFT_ARTIFACT" docker-daemon:rockcraft-test:latest


### PR DESCRIPTION
Bump `build-base` from `devel` to `ubuntu@26.04` for version 1.28 (base remains `bare`). Resolves the TODO comment.